### PR TITLE
Release/0.2.0

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.2.0 /2025-01-08
+## v0.2.0 /2025-01-15
 
 ## What's Changed
 * fix epoch jump when epoch_block is close by @JohnReedV in https://github.com/opentensor/bittensor-commit-reveal/pull/12

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.2.0 /2025-01-08
+
+## What's Changed
+* fix epoch jump when epoch_block is close by @JohnReedV in https://github.com/opentensor/bittensor-commit-reveal/pull/12
+* Backmerge staging to main 0.1.0 @ibraheem-opentensor in https://github.com/opentensor/bittensor-commit-reveal/pull/13
+
+**Full Changelog**: https://github.com/opentensor/bittensor-commit-reveal/compare/v0.1.0...v0.2.0
+
 ## v0.1.0 /2024-12-12
 
 ## What's Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bittensor-commit-reveal"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [lib]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bittensor-commit-reveal"
-version = "0.1.0"
+version = "0.2.0"
 description = ""
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/tests/test_commit_reveal.py
+++ b/src/tests/test_commit_reveal.py
@@ -153,9 +153,6 @@ async def test_generate_commit_various_tempos():
             f"Not enough lead time: reveal_time={computed_reveal_time}, "
             f"start_time={start_time}, required={required_lead_time}"
         )
-    else:
-        pass
-
 
 
 def compute_expected_reveal_round(


### PR DESCRIPTION
## v0.2.0 /2025-01-08

## What's Changed
* fix epoch jump when epoch_block is close by @JohnReedV in https://github.com/opentensor/bittensor-commit-reveal/pull/12
* Backmerge staging to main 0.1.0 @ibraheem-opentensor in https://github.com/opentensor/bittensor-commit-reveal/pull/13

**Full Changelog**: https://github.com/opentensor/bittensor-commit-reveal/compare/v0.1.0...v0.2.0