### PR TITLE
Add `get_encrypted_commitment`

### DIFF
--- a/.github/workflows/check-sdk-tests.yml
+++ b/.github/workflows/check-sdk-tests.yml
@@ -1,0 +1,219 @@
+name: Bittensor SDK Test
+
+permissions:
+  pull-requests: write
+  contents: read
+
+concurrency:
+  group: e2e-sdk-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    branches:
+      - main
+      - staging
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+env:
+  CARGO_TERM_COLOR: always
+  VERBOSE: ${{ github.event.inputs.verbose }}
+
+jobs:
+  apply-label-to-new-pr:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.draft == false }}
+    outputs:
+      should_continue_sdk: ${{ steps.check.outputs.should_continue_sdk }}
+    steps:
+      - name: Check
+        id: check
+        run: |
+          ACTION="${{ github.event.action }}"
+          if [[ "$ACTION" == "opened" || "$ACTION" == "reopened" ]]; then
+            echo "should_continue_sdk=true" >> $GITHUB_OUTPUT
+          else
+            echo "should_continue_sdk=false" >> $GITHUB_OUTPUT
+          fi
+        shell: bash
+
+      - name: Add label
+        if: steps.check.outputs.should_continue_sdk == 'true'
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: run-bittensor-sdk-tests
+
+  check-labels:
+    needs: apply-label-to-new-pr
+    runs-on: ubuntu-latest
+    if: always()
+    outputs:
+      run-sdk-tests: ${{ steps.get-labels.outputs.run-sdk-tests }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Get labels from PR
+        id: get-labels
+        run: |
+          sleep 5
+          LABELS=$(gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels --jq '.[].name')
+          echo "Current labels: $LABELS"
+          if echo "$LABELS" | grep -q "run-bittensor-sdk-tests"; then
+            echo "run-sdk-tests=true" >> $GITHUB_OUTPUT
+          else
+            echo "run-sdk-tests=false" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  find-e2e-tests:
+    needs: check-labels
+    if: always() && needs.check-labels.outputs.run-sdk-tests == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      test-files: ${{ steps.get-tests.outputs.test-files }}
+    steps:
+      - name: Research preparation
+        working-directory: ${{ github.workspace }}
+        run: git clone https://github.com/opentensor/bittensor.git
+
+      - name: Checkout
+        working-directory: ${{ github.workspace }}/bittensor
+        run: git checkout staging
+
+      - name: Install dependencies
+        run: sudo apt-get install -y jq
+
+      - name: Find e2e test files
+        id: get-tests
+        run: |
+          test_files=$(find ${{ github.workspace }}/bittensor/tests/e2e_tests -name "test*.py" | jq -R -s -c 'split("\n") | map(select(. != ""))')
+          echo "::set-output name=test-files::$test_files"
+        shell: bash
+
+  pull-docker-image:
+    needs: check-labels
+    runs-on: ubuntu-latest
+    if: always() && needs.check-labels.outputs.run-sdk-tests == 'true'
+    steps:
+      - name: Log in to GitHub Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
+
+      - name: Pull Docker Image
+        run: docker pull ghcr.io/opentensor/subtensor-localnet:devnet-ready
+
+      - name: Save Docker Image to Cache
+        run: docker save -o subtensor-localnet.tar ghcr.io/opentensor/subtensor-localnet:devnet-ready
+
+      - name: Upload Docker Image as Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: subtensor-localnet
+          path: subtensor-localnet.tar
+
+  run-e2e-tests:
+    needs:
+      - check-labels
+      - find-e2e-tests
+      - pull-docker-image
+
+    if: always() && needs.check-labels.outputs.run-sdk-tests == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 16
+      matrix:
+        rust-branch:
+          - stable
+        rust-target:
+          - x86_64-unknown-linux-gnu
+        os:
+          - ubuntu-latest
+        test-file: ${{ fromJson(needs.find-e2e-tests.outputs.test-files) }}
+
+    env:
+      RELEASE_NAME: development
+      RUSTV: ${{ matrix.rust-branch }}
+      RUST_BACKTRACE: full
+      RUST_BIN_DIR: target/${{ matrix.rust-target }}
+      TARGET: ${{ matrix.rust-target }}
+
+    timeout-minutes: 60
+    name: "e2e tests: ${{ matrix.test-file }}"
+    steps:
+      - name: Check-out repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust stable
+        uses: actions-rs/toolchain@v1.0.6
+        with:
+          toolchain: ${{ matrix.rust-branch }}
+          components: rustfmt
+          profile: minimal
+
+      - name: Install rust/cargo dependencies
+        run: |
+          sudo apt-get update &&
+          sudo apt-get install -y clang curl libssl-dev llvm libudev-dev protobuf-compiler jq
+
+      - name: Add wasm32-unknown-unknown target
+        run: |
+          rustup target add wasm32-unknown-unknown --toolchain stable-x86_64-unknown-linux-gnu
+          rustup component add rust-src --toolchain stable-x86_64-unknown-linux-gnu
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Create Python virtual environment
+        working-directory: ${{ github.workspace }}
+        run: uv venv ${{ github.workspace }}/venv
+
+      - name: Clone Bittensor SDK repo
+        working-directory: ${{ github.workspace }}
+        run: git clone https://github.com/opentensor/bittensor.git
+
+      - name: Setup Bittensor SDK from cloned repo
+        working-directory: ${{ github.workspace }}/bittensor
+        run: |
+          source ${{ github.workspace }}/venv/bin/activate
+          git checkout staging
+          git fetch origin staging
+          uv run --active pip install --upgrade pip
+          uv run --active pip install '.[dev]'
+          uv run --active pip install maturin
+
+      - name: Install uv dependencies
+        working-directory: ${{ github.workspace }}
+        run: uv sync --all-extras --dev
+
+      - name: Clone bittensor_commit_reveal repo
+        run: git clone https://github.com/opentensor/bittensor-commit-reveal.git
+
+      - name: Checkout PR branch in bittensor_commit_reveal repo
+        working-directory: ${{ github.workspace }}/btwallet
+        run: |
+          git fetch origin ${{ github.event.pull_request.head.ref }}
+          git checkout ${{ github.event.pull_request.head.ref }}
+          echo "Current branch: $(git rev-parse --abbrev-ref HEAD)"
+
+      - name: Build and install Rust bittensor_commit_reveal package
+        working-directory: ${{ github.workspace }}
+        run: |
+          source ${{ github.workspace }}/venv/bin/activate
+          uv run --active maturin develop
+
+      - name: Download Cached Docker Image
+        uses: actions/download-artifact@v4
+        with:
+          name: subtensor-localnet
+
+      - name: Load Docker Image
+        run: docker load -i subtensor-localnet.tar
+
+      - name: Run tests
+        working-directory: ${{ github.workspace }}
+        run: |
+          source ${{ github.workspace }}/venv/bin/activate
+          uv run pytest ${{ matrix.test-file }} -s

--- a/.github/workflows/check-sdk-tests.yml
+++ b/.github/workflows/check-sdk-tests.yml
@@ -168,8 +168,7 @@ jobs:
 
       - name: Create Python virtual environment
         working-directory: ${{ github.workspace }}
-        run: |
-          python -m venv ${{ github.workspace }}/venv
+        run: uv venv ${{ github.workspace }}/venv
 
       - name: Clone Bittensor SDK repo
         working-directory: ${{ github.workspace }}
@@ -189,11 +188,20 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: uv sync --all-extras --dev
 
-      - name: Check-out repository
-        uses: actions/checkout@v4
+      - name: Clone bittensor-commit-reveal repo
+        run: git clone https://github.com/opentensor/bittensor-commit-reveal.git
 
-      - name: Build and install Rust bittensor_commit_reveal package
+      - name: Checkout PR branch in bittensor-commit-reveal repo
+        working-directory: ${{ github.workspace }}/bittensor-commit-reveal
         run: |
+          git fetch origin ${{ github.event.pull_request.head.ref }}
+          git checkout ${{ github.event.pull_request.head.ref }}
+          echo "Current branch: $(git rev-parse --abbrev-ref HEAD)"
+
+      - name: Build and install bittensor-commit-reveal repo package
+        working-directory: ${{ github.workspace }}
+        run: |
+          source ${{ github.workspace }}/venv/bin/activate
           uv run --active maturin develop
 
       - name: Download Cached Docker Image

--- a/.github/workflows/check-sdk-tests.yml
+++ b/.github/workflows/check-sdk-tests.yml
@@ -192,7 +192,7 @@ jobs:
         run: git clone https://github.com/opentensor/bittensor-commit-reveal.git
 
       - name: Checkout PR branch in bittensor_commit_reveal repo
-        working-directory: ${{ github.workspace }}/btwallet
+        working-directory: ${{ github.workspace }}/bittensor-commit-reveal
         run: |
           git fetch origin ${{ github.event.pull_request.head.ref }}
           git checkout ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/check-sdk-tests.yml
+++ b/.github/workflows/check-sdk-tests.yml
@@ -168,7 +168,8 @@ jobs:
 
       - name: Create Python virtual environment
         working-directory: ${{ github.workspace }}
-        run: uv venv ${{ github.workspace }}/venv
+        run: |
+          python -m venv ${{ github.workspace }}/venv
 
       - name: Clone Bittensor SDK repo
         working-directory: ${{ github.workspace }}
@@ -193,7 +194,6 @@ jobs:
 
       - name: Build and install Rust bittensor_commit_reveal package
         run: |
-          source ${{ github.workspace }}/venv/bin/activate
           uv run --active maturin develop
 
       - name: Download Cached Docker Image

--- a/.github/workflows/check-sdk-tests.yml
+++ b/.github/workflows/check-sdk-tests.yml
@@ -188,18 +188,10 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: uv sync --all-extras --dev
 
-      - name: Clone bittensor_commit_reveal repo
-        run: git clone https://github.com/opentensor/bittensor-commit-reveal.git
-
-      - name: Checkout PR branch in bittensor_commit_reveal repo
-        working-directory: ${{ github.workspace }}/bittensor-commit-reveal
-        run: |
-          git fetch origin ${{ github.event.pull_request.head.ref }}
-          git checkout ${{ github.event.pull_request.head.ref }}
-          echo "Current branch: $(git rev-parse --abbrev-ref HEAD)"
+      - name: Check-out repository
+        uses: actions/checkout@v4
 
       - name: Build and install Rust bittensor_commit_reveal package
-        working-directory: ${{ github.workspace }}
         run: |
           source ${{ github.workspace }}/venv/bin/activate
           uv run --active maturin develop

--- a/.github/workflows/check-sdk-tests.yml
+++ b/.github/workflows/check-sdk-tests.yml
@@ -216,4 +216,4 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: |
           source ${{ github.workspace }}/venv/bin/activate
-          uv run pytest ${{ matrix.test-file }} -s
+          pytest ${{ matrix.test-file }} -s

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         uses: PyO3/maturin-action@v1.44.0
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter
+          args: --release --out dist --interpreter python3.10
           sccache: 'true'
           manylinux: auto
           before-script-linux: (apt-get update && apt-get install -y apt-utils && apt-get install -y pkg-config libssl-dev) || (yum install openssl openssl-devel -y) 
@@ -102,7 +102,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@v2
         with:
           subject-path: 'wheels-*/*'
       - name: Publish to PyPI

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.x
+          python-version: "3.10"
       - name: Build wheels
         uses: PyO3/maturin-action@v1.44.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.x
+          python-version: "3.10"
       - name: Build wheels
         uses: PyO3/maturin-action@v1.44.0
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,7 +240,7 @@ checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "bittensor-commit-reveal"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "ark-serialize",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bittensor-commit-reveal"
-version = "0.1.0"
+version = "0.3.0"
 edition = "2021"
 
 [lib]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bittensor-commit-reveal"
-version = "0.1.0"
+version = "0.3.0"
 description = ""
 readme = "README.md"
 license = {file = "LICENSE"}
@@ -10,7 +10,7 @@ dependencies = []
 requires-python = ">= 3.9"
 
 authors = [
-  {name = "Roman Chkhaidze", email = "roman@opentensor.dev"},
+  {name = "Roman Chkhaidze", email = "r@latent.to"},
 ]
 maintainers = [
   {name = "Cortex Team", email = "cortex@opentensor.dev"},
@@ -30,7 +30,8 @@ classifiers = [
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
         "Topic :: Software Development",
         "Topic :: Software Development :: Libraries",
-        "Topic :: Software Development :: Libraries :: Python Modules",]
+        "Topic :: Software Development :: Libraries :: Python Modules",
+]
 
 [project.urls]
 Repository = "https://github.com/opentensor/bittensor-commit-reveal"
@@ -45,5 +46,6 @@ exclude = ["tests*"]
 
 [project.optional-dependencies]
 dev = [
-    "maturin==1.7.0"
+    "maturin==1.7.0",
+    "pytest-asyncio==0.23.7"
 ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,7 +172,8 @@ async fn generate_commit(
     }
 
     let reveal_time = now + time_until_reveal;
-    let reveal_round = ((reveal_time - GENESIS_TIME as f64) / DRAND_PERIOD as f64).ceil() as u64 - SUBTENSOR_PULSE_DELAY;
+    let reveal_round = ((reveal_time - GENESIS_TIME as f64) / DRAND_PERIOD as f64).ceil() as u64
+        - SUBTENSOR_PULSE_DELAY;
 
     let ct_bytes = encrypt_and_compress(&serialized_payload, reveal_round)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,10 @@ use tle::{
 use tokio;
 use w3f_bls::EngineBLS;
 
-pub const SUBTENSOR_PULSE_DELAY: u64 = 24;
+pub const SUBTENSOR_PULSE_DELAY: u64 = 24; //Drand rounds amount
+const PUBLIC_KEY: &str = "83cf0f2896adee7eb8b5f01fcad3912212c437e0073e911fb90022d3e760183c8c4b450b6a0a6c3ac6a5776a2d1064510d1fec758c921cc22b0e17e63aaf4bcb5ed66304de9cf809bd274ca73bab4af5a6e9c76a4bc09e76eae8991ef5ece45a";
+const GENESIS_TIME: u64 = 1692803367;
+const DRAND_PERIOD: u64 = 3;
 
 #[derive(Encode)]
 pub struct WeightsTlockPayload {
@@ -22,63 +25,40 @@ pub struct WeightsTlockPayload {
     pub version_key: u64,
 }
 
-async fn generate_commit(
-    uids: Vec<u16>,
-    values: Vec<u16>,
-    version_key: u64,
-    tempo: u64,
-    current_block: u64,
-    netuid: u16,
-    subnet_reveal_period_epochs: u64,
-    block_time: u64,
-) -> Result<(Vec<u8>, u64), (std::io::Error, String)> {
-    // Steps comes from here https://github.com/opentensor/subtensor/pull/982/files#diff-7261bf1c7f19fc66a74c1c644ec2b4b277a341609710132fb9cd5f622350a6f5R120-R131
-    // Instantiate payload
-    let payload = WeightsTlockPayload {
-        uids,
-        values,
-        version_key,
-    };
-    let serialized_payload = payload.encode();
-
-    let period = 3;
-    let genesis_time = 1692803367;
-    let public_key = "83cf0f2896adee7eb8b5f01fcad3912212c437e0073e911fb90022d3e760183c8c4b450b6a0a6c3ac6a5776a2d1064510d1fec758c921cc22b0e17e63aaf4bcb5ed66304de9cf809bd274ca73bab4af5a6e9c76a4bc09e76eae8991ef5ece45a";
-
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_secs();
-
-    let tempo_plus_one = tempo + 1;
-    let netuid_plus_one = (netuid as u64) + 1;
-    let block_with_offset = current_block + netuid_plus_one;
-    let current_epoch = block_with_offset / tempo_plus_one;
-
-    // Calculate reveal epoch and ensure enough time for SUBTENSOR_PULSE_DELAY pulses
-    let mut reveal_epoch = current_epoch + subnet_reveal_period_epochs;
-    let mut reveal_block_number = reveal_epoch * tempo_plus_one - netuid_plus_one;
-    let mut blocks_until_reveal = reveal_block_number - current_block;
-    let mut time_until_reveal = blocks_until_reveal * block_time;
-
-    // Ensure at least SUBTENSOR_PULSE_DELAY * period seconds lead time
-    while time_until_reveal < SUBTENSOR_PULSE_DELAY * period {
-
-        if blocks_until_reveal > 1 {
-            break;
-        }
-
-        reveal_epoch += 1;
-        reveal_block_number = reveal_epoch * tempo_plus_one - netuid_plus_one;
-        blocks_until_reveal = reveal_block_number - current_block;
-        time_until_reveal = blocks_until_reveal * block_time;
-    }
-
-    let reveal_time = now + time_until_reveal;
-    let reveal_round = ((reveal_time - genesis_time + period - 1) / period) - SUBTENSOR_PULSE_DELAY;
-
+/// Encrypts and compresses the provided serialized data for secure transfer.
+///
+/// # Arguments
+///
+/// * `serialized_data` - A slice of bytes containing the serialized data to be encrypted.
+/// * `reveal_round` - A `u64` value representing the round during which the encryption will be revealed.
+///
+/// # Returns
+///
+/// Returns a `Result` which is:
+/// * `Ok(Vec<u8>)` containing the compressed and encrypted bytes if the process succeeds.
+/// * `Err((std::io::Error, String))` if an error occurs during decoding, public key deserialization,
+///   encryption, or ciphertext compression.
+///
+/// # Example
+///
+/// ```rust
+/// let serialized_data = b"example_data";
+/// let reveal_round = 42;
+/// match encrypt_and_compress(serialized_data, reveal_round) {
+///     Ok(encrypted_data) => {
+///         println!("Encrypted and compressed data: {:?}", encrypted_data);
+///     }
+///     Err((err, message)) => {
+///         eprintln!("Error: {}, Message: {}", err, message);
+///     }
+/// }
+/// ```
+fn encrypt_and_compress(
+    serialized_data: &[u8],
+    reveal_round: u64,
+) -> Result<Vec<u8>, (std::io::Error, String)> {
     // Deserialize public key
-    let pub_key_bytes = hex::decode(public_key).map_err(|e| {
+    let pub_key_bytes = hex::decode(PUBLIC_KEY).map_err(|e| {
         (
             std::io::Error::new(std::io::ErrorKind::InvalidData, format!("{:?}", e)),
             "Decoding public key failed.".to_string(),
@@ -106,7 +86,7 @@ async fn generate_commit(
     let ct = tle::<TinyBLS381, AESGCMStreamCipherProvider, OsRng>(
         pub_key,
         esk,
-        &serialized_payload,
+        &serialized_data,
         identity,
         OsRng,
     )
@@ -125,6 +105,80 @@ async fn generate_commit(
             "Ciphertext serialization failed.".to_string(),
         )
     })?;
+
+    Ok(ct_bytes)
+}
+
+/// Generates a commit containing a payload to be encrypted and information about the reveal round,
+/// along with the timestamped reveal round for the network.
+///
+/// # Arguments
+///
+/// * `uids` - A vector of unique identifiers (UIDs).
+/// * `values` - A vector of associated values for the UIDs.
+/// * `version_key` - A u64 value representing the version key for the commit.
+/// * `tempo` - A u64 specifying the tempo (block interval) for the network.
+/// * `current_block` - The current block number as u64.
+/// * `netuid` - A u16 representing the network's unique identifier.
+/// * `subnet_reveal_period_epochs` - A u64 indicating the number of epochs before reveal.
+/// * `block_time` - Duration of each block in seconds as u64.
+///
+/// # Returns
+///
+/// A `Result` which is:
+/// * `Ok((Vec<u8>, u64))` containing the encrypted commit payload and the calculated reveal round timestamp if successful.
+/// * `Err((std::io::Error, String))` if an error occurs during payload serialization, encryption, or other processing steps.
+async fn generate_commit(
+    uids: Vec<u16>,
+    values: Vec<u16>,
+    version_key: u64,
+    tempo: u64,
+    current_block: u64,
+    netuid: u16,
+    subnet_reveal_period_epochs: u64,
+    block_time: u64,
+) -> Result<(Vec<u8>, u64), (std::io::Error, String)> {
+    // Steps comes from here https://github.com/opentensor/subtensor/pull/982/files#diff-7261bf1c7f19fc66a74c1c644ec2b4b277a341609710132fb9cd5f622350a6f5R120-R131
+    // Instantiate payload
+    let payload = WeightsTlockPayload {
+        uids,
+        values,
+        version_key,
+    };
+    let serialized_payload = payload.encode();
+
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+
+    let tempo_plus_one = tempo + 1;
+    let netuid_plus_one = (netuid as u64) + 1;
+    let block_with_offset = current_block + netuid_plus_one;
+    let current_epoch = block_with_offset / tempo_plus_one;
+
+    // Calculate reveal epoch and ensure enough time for SUBTENSOR_PULSE_DELAY pulses
+    let mut reveal_epoch = current_epoch + subnet_reveal_period_epochs;
+    let mut reveal_block_number = reveal_epoch * tempo_plus_one - netuid_plus_one;
+    let mut blocks_until_reveal = reveal_block_number - current_block;
+    let mut time_until_reveal = blocks_until_reveal * block_time;
+
+    // Ensure at least SUBTENSOR_PULSE_DELAY * DRAND_PERIOD seconds lead time
+    while time_until_reveal < SUBTENSOR_PULSE_DELAY * DRAND_PERIOD {
+        if blocks_until_reveal > 1 {
+            break;
+        }
+
+        reveal_epoch += 1;
+        reveal_block_number = reveal_epoch * tempo_plus_one - netuid_plus_one;
+        blocks_until_reveal = reveal_block_number - current_block;
+        time_until_reveal = blocks_until_reveal * block_time;
+    }
+
+    let reveal_time = now + time_until_reveal;
+    let reveal_round =
+        ((reveal_time - GENESIS_TIME + DRAND_PERIOD - 1) / DRAND_PERIOD) - SUBTENSOR_PULSE_DELAY;
+    let ct_bytes = encrypt_and_compress(&serialized_payload, reveal_round)?;
 
     Ok((ct_bytes, reveal_round))
 }
@@ -165,8 +219,78 @@ fn get_encrypted_commit(
     }
 }
 
+async fn encrypt_commitment(
+    data: &str,
+    current_block: u64,
+    reveal_block: u64,
+    block_time: u64,
+) -> Result<(Vec<u8>, u64), (std::io::Error, String)> {
+    let serialized_data = data.encode();
+
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    println!(">>> now: {:?}", now);
+    println!(">>> now - GENESIS_TIME: {:?}", now - GENESIS_TIME);
+
+    let current_round = (now - GENESIS_TIME) / DRAND_PERIOD;
+    println!(">>> current_round: {:?}", current_round);
+
+    println!(">>> reveal_block: {:?} / current_block: {:?}", reveal_block, current_block);
+
+    let in_blocks = reveal_block - current_block;
+    let in_blocks_time = in_blocks * block_time;
+    let in_rounds = in_blocks_time / DRAND_PERIOD;
+    let drand_round = current_round + in_rounds;
+    println!(">>> drand_round: {:?}", drand_round);
+    let reveal_round = drand_round - SUBTENSOR_PULSE_DELAY;
+
+    // let reveal_round = (((reveal_block - current_block + 1) * block_time) / DRAND_PERIOD
+    //     + current_round)
+    //     - SUBTENSOR_PULSE_DELAY;
+    println!(">>> reveal_round: {:?}", reveal_round);
+
+    let ct_bytes = encrypt_and_compress(&serialized_data, reveal_round).map_err(|e| {
+        (
+            std::io::Error::new(std::io::ErrorKind::Other, format!("{:?}", e)),
+            "Encryption failed.".to_string(),
+        )
+    })?;
+    Ok((ct_bytes, reveal_round))
+}
+
+#[pyfunction]
+#[pyo3(signature = (data, current_block, reveal_block, block_time=12))]
+fn get_encrypted_commitment(
+    py: Python,
+    data: &str,
+    current_block: u64,
+    reveal_block: u64,
+    block_time: u64,
+) -> PyResult<(Py<PyBytes>, u64)> {
+    // create runtime to make async call
+    let runtime =
+        tokio::runtime::Runtime::new().map_err(|e| PyValueError::new_err(e.to_string()))?;
+    let result = runtime.block_on(encrypt_commitment(
+        data,
+        current_block,
+        reveal_block,
+        block_time,
+    ));
+    // matching the result
+    match result {
+        Ok((ciphertext, target_round)) => {
+            let py_bytes = PyBytes::new_bound(py, &ciphertext).into();
+            Ok((py_bytes, target_round))
+        }
+        Err(e) => Err(PyValueError::new_err(format!("{:?}", e))),
+    }
+}
+
 #[pymodule]
 fn bittensor_commit_reveal(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(get_encrypted_commit, m)?)?;
+    m.add_function(wrap_pyfunction!(get_encrypted_commitment, m)?)?;
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,12 +252,12 @@ async fn encrypt_commitment(
 }
 
 #[pyfunction]
-#[pyo3(signature = (data, current_block, reveal_block, block_time=12.0))]
+#[pyo3(signature = (data, current_block, blocks_until_reveal, block_time=12.0))]
 fn get_encrypted_commitment(
     py: Python,
     data: &str,
     current_block: u64,
-    reveal_block: u64,
+    blocks_until_reveal: u64,
     block_time: f64,
 ) -> PyResult<(Py<PyBytes>, u64)> {
     // create runtime to make async call
@@ -266,7 +266,7 @@ fn get_encrypted_commitment(
     let result = runtime.block_on(encrypt_commitment(
         data,
         current_block,
-        reveal_block,
+        blocks_until_reveal,
         block_time,
     ));
     // matching the result

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,15 +227,11 @@ async fn encrypt_commitment(
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap()
-        .as_secs_f64();
+        .as_secs();
 
-    let current_round = ((now - GENESIS_TIME as f64) / DRAND_PERIOD as f64).floor() as u64;
-
-    let in_blocks_time = blocks_until_reveal as f64 * block_time;
-    let in_rounds = (in_blocks_time / DRAND_PERIOD as f64).ceil() as u64;
-
-    let drand_round = current_round + in_rounds;
-    let reveal_round = drand_round - SUBTENSOR_PULSE_DELAY;
+    let reveal_round = ((now - GENESIS_TIME)
+        + (blocks_until_reveal as f64 * block_time).round() as u64)
+        / DRAND_PERIOD;
 
     // TLE encoding
     let ct_bytes = encrypt_and_compress(&serialized_data, reveal_round).map_err(|e| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,9 +246,7 @@ async fn encrypt_commitment(
         )
     })?;
 
-    let reveal_block = current_block + blocks_until_reveal;
-
-    Ok((ct_bytes, reveal_block))
+    Ok((ct_bytes, reveal_round))
 }
 
 #[pyfunction]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,7 +218,6 @@ fn get_encrypted_commit(
 
 async fn encrypt_commitment(
     data: &str,
-    current_block: u64,
     blocks_until_reveal: u64,
     block_time: f64,
 ) -> Result<(Vec<u8>, u64), (std::io::Error, String)> {
@@ -250,23 +249,17 @@ async fn encrypt_commitment(
 }
 
 #[pyfunction]
-#[pyo3(signature = (data, current_block, blocks_until_reveal, block_time=12.0))]
+#[pyo3(signature = (data, blocks_until_reveal, block_time=12.0))]
 fn get_encrypted_commitment(
     py: Python,
     data: &str,
-    current_block: u64,
     blocks_until_reveal: u64,
     block_time: f64,
 ) -> PyResult<(Py<PyBytes>, u64)> {
     // create runtime to make async call
     let runtime =
         tokio::runtime::Runtime::new().map_err(|e| PyValueError::new_err(e.to_string()))?;
-    let result = runtime.block_on(encrypt_commitment(
-        data,
-        current_block,
-        blocks_until_reveal,
-        block_time,
-    ));
+    let result = runtime.block_on(encrypt_commitment(data, blocks_until_reveal, block_time));
     // matching the result
     match result {
         Ok((ciphertext, target_round)) => {

--- a/tests/test_commit_reveal.py
+++ b/tests/test_commit_reveal.py
@@ -157,7 +157,6 @@ async def test_generate_commit_various_tempos():
         pass
 
 
-
 def compute_expected_reveal_round(
     now: int,
     tempo: int,


### PR DESCRIPTION
- added `get_encrypted_commitment`
- refactored whole lib
- calculation adapted for working with `fast blocks` nodes
- added `SDK` e2e tests workflow
- python tests moved out of src folder
- version bumped to `0.3.0`